### PR TITLE
Feature/hint compat api css logic deprecated

### DIFF
--- a/packages/hint-compat-api/src/compat-api-css.ts
+++ b/packages/hint-compat-api/src/compat-api-css.ts
@@ -13,6 +13,7 @@ import { find, forEach } from 'lodash';
 import { CompatApi, userBrowsers } from './helpers';
 import { FeatureStrategy, MDNTreeFilteredByBrowsers, BrowserSupportCollection } from './types';
 import { SupportBlock } from './types-mdn.temp';
+import { browserVersions } from './helpers/normalize-version';
 
 const debug: debug.IDebugger = d(__filename);
 
@@ -85,7 +86,7 @@ export default class implements IHint {
                     }
 
                     // If the version is smaller than the browser supported, should fail
-                    const removedVersionNumber = Number(removedVersion);
+                    const removedVersionNumber = browserVersions.normalize(removedVersion);
                     let notSupportedVersions: string[] = [];
                     forEach(browsersToSupport, (versions, browserName) => {
                         versions.forEach(version => {
@@ -93,7 +94,7 @@ export default class implements IHint {
                                 return;
                             }
 
-                            notSupportedVersions.push(`${browserName} ${version}`);
+                            notSupportedVersions.push(`${browserName} ${browserVersions.deNormalize(version)}`);
                         });
                     });
 

--- a/packages/hint-compat-api/src/compat-api-css.ts
+++ b/packages/hint-compat-api/src/compat-api-css.ts
@@ -54,7 +54,7 @@ export default class implements IHint {
 
                 // If feature is not in the filtered by browser data, that means that is always supported.
                 if (!feature) {
-                    return
+                    return;
                 }
 
                 // If feature does not have compat data, we ignore it.
@@ -66,8 +66,9 @@ export default class implements IHint {
 
                 // Check for each browser the support block
                 const supportBlock: SupportBlock = featureInfo.support;
-                forEach(supportBlock, browserInfo => {
-                    let browserFeatureSupported = compatApi.getSupportStatementFromInfo(browserInfo, prefix);
+
+                forEach(supportBlock, (browserInfo) => {
+                    const browserFeatureSupported = compatApi.getSupportStatementFromInfo(browserInfo, prefix);
 
                     // If we dont have information about the compatibility, ignore.
                     if (!browserFeatureSupported) {
@@ -90,9 +91,10 @@ export default class implements IHint {
 
                     // If the version is smaller than the browser supported, should fail
                     const removedVersionNumber = browserVersions.normalize(removedVersion);
-                    let notSupportedVersions: string[] = [];
+                    const notSupportedVersions: string[] = [];
+
                     forEach(browsersToSupport, (versions, browserName) => {
-                        versions.forEach(version => {
+                        versions.forEach((version) => {
                             if (version <= removedVersionNumber) {
                                 return;
                             }

--- a/packages/hint-compat-api/src/compat-api-css.ts
+++ b/packages/hint-compat-api/src/compat-api-css.ts
@@ -37,9 +37,12 @@ export default class implements IHint {
 
     public constructor(context: HintContext) {
         const onParseCSS = (styleParse: StyleParse): void => {
+            const mdnBrowsersCollection = userBrowsers.convert(context.targetedBrowsers);
+            const compatApi = new CompatApi('css', mdnBrowsersCollection);
 
             const checkDeprecatedCSSFeature = (keyName: string, name: string, data: MDNTreeFilteredByBrowsers, browsersToSupport: BrowserSupportCollection): void => {
                 const key: any = data[keyName];
+                const [prefix, featureName] = compatApi.getPrefix(name);
 
                 if (!key) {
                     debug('error');
@@ -47,7 +50,7 @@ export default class implements IHint {
                     return;
                 }
 
-                const feature = key[name];
+                const feature = key[featureName];
 
                 // If feature is not in the filtered by browser data, that means that is always supported.
                 if (!feature) {
@@ -64,7 +67,7 @@ export default class implements IHint {
                 // Check for each browser the support block
                 const supportBlock: SupportBlock = featureInfo.support;
                 forEach(supportBlock, browserInfo => {
-                    let browserFeatureSupported = compatApi.getSupportStatementFromInfo(browserInfo);
+                    let browserFeatureSupported = compatApi.getSupportStatementFromInfo(browserInfo, prefix);
 
                     // If we dont have information about the compatibility, ignore.
                     if (!browserFeatureSupported) {
@@ -170,9 +173,6 @@ export default class implements IHint {
                     strategy.testFeature(node, data, browsers);
                 });
             };
-
-            const mdnBrowsersCollection = userBrowsers.convert(context.targetedBrowsers);
-            const compatApi = new CompatApi('css', mdnBrowsersCollection);
 
             searchDeprecatedCSSFeatures(compatApi.compatDataApi, mdnBrowsersCollection, styleParse);
         };

--- a/packages/hint-compat-api/src/compat-api-css.ts
+++ b/packages/hint-compat-api/src/compat-api-css.ts
@@ -45,7 +45,7 @@ export default class implements IHint {
                 const [prefix, featureName] = compatApi.getPrefix(name);
 
                 if (!key) {
-                    debug('error');
+                    debug('Error: The keyname does not exist.');
 
                     return;
                 }
@@ -66,20 +66,23 @@ export default class implements IHint {
 
                 // Check for each browser the support block
                 const supportBlock: SupportBlock = featureInfo.support;
-
                 forEach(supportBlock, (browserInfo, browserToSupportName) => {
                     const browserFeatureSupported = compatApi.getSupportStatementFromInfo(browserInfo, prefix);
 
                     // If we dont have information about the compatibility, its an error.
                     if (!browserFeatureSupported) {
+                        let wasSupportedInSometime = false;
                         forEach(browsersToSupport, (versions, browserName) => {
                             if (browserName !== browserToSupportName) {
                                 return;
                             }
 
-                            debug('error');
+                           wasSupportedInSometime = true;
                         });
 
+                        if (!wasSupportedInSometime) {
+                            debug(`${featureName} of CSS was never supported on ${browserToSupportName} browser.`);
+                        }
                         return;
                     }
 
@@ -92,7 +95,7 @@ export default class implements IHint {
 
                     // Not a common case, but if removed version is exactly true, is always deprecated.
                     if (removedVersion === true) {
-                        debug('error');
+                        debug(`${featureName} of CSS is not supported on ${browserToSupportName} browser.`);
 
                         return;
                     }
@@ -116,7 +119,7 @@ export default class implements IHint {
                     });
 
                     if (notSupportedVersions.length > 0) {
-                        debug(`Error in feature ${name} on browsers ${notSupportedVersions.join(', ')}`);
+                        debug(`${featureName} of CSS is not supported on ${notSupportedVersions.join(', ')} browsers.`);
                     }
                 });
             };

--- a/packages/hint-compat-api/src/compat-api-css.ts
+++ b/packages/hint-compat-api/src/compat-api-css.ts
@@ -77,7 +77,7 @@ export default class implements IHint {
                         return;
                     }
 
-                    // Not a common case, but if removed version is true, is always deprecated.
+                    // Not a common case, but if removed version is exactly true, is always deprecated.
                     if (removedVersion === true) {
                         debug('error');
 
@@ -85,9 +85,21 @@ export default class implements IHint {
                     }
 
                     // If the version is smaller than the browser supported, should fail
-                    forEach(browsersToSupport, browserName => {
-                        debugger;
+                    const removedVersionNumber = Number(removedVersion);
+                    let notSupportedVersions: string[] = [];
+                    forEach(browsersToSupport, (versions, browserName) => {
+                        versions.forEach(version => {
+                            if (version <= removedVersionNumber) {
+                                return;
+                            }
+
+                            notSupportedVersions.push(`${browserName} ${version}`);
+                        });
                     });
+
+                    if (notSupportedVersions.length > 0) {
+                        debug(`Error in feature ${name} on browsers ${notSupportedVersions.join(', ')}`);
+                    }
                 });
             };
 
@@ -108,7 +120,7 @@ export default class implements IHint {
                     },
 
                     testFeature: (node: Rule, data, browsers) => {
-                        checkDeprecatedCSSFeature('at-rules', node.selector, data, browsers);
+                        // checkDeprecatedCSSFeature('at-rules', node.selector, data, browsers);
                     }
                 };
 
@@ -118,7 +130,7 @@ export default class implements IHint {
                     },
 
                     testFeature: (node: Declaration, data, browsers) => {
-                        checkDeprecatedCSSFeature('at-rules', node.value, data, browsers);
+                        // checkDeprecatedCSSFeature('at-rules', node.value, data, browsers);
                     }
                 };
 

--- a/packages/hint-compat-api/src/compat-api-css.ts
+++ b/packages/hint-compat-api/src/compat-api-css.ts
@@ -67,11 +67,19 @@ export default class implements IHint {
                 // Check for each browser the support block
                 const supportBlock: SupportBlock = featureInfo.support;
 
-                forEach(supportBlock, (browserInfo) => {
+                forEach(supportBlock, (browserInfo, browserToSupportName) => {
                     const browserFeatureSupported = compatApi.getSupportStatementFromInfo(browserInfo, prefix);
 
-                    // If we dont have information about the compatibility, ignore.
+                    // If we dont have information about the compatibility, its an error.
                     if (!browserFeatureSupported) {
+                        forEach(browsersToSupport, (versions, browserName) => {
+                            if (browserName !== browserToSupportName) {
+                                return;
+                            }
+
+                            debug('error');
+                        });
+
                         return;
                     }
 
@@ -94,8 +102,12 @@ export default class implements IHint {
                     const notSupportedVersions: string[] = [];
 
                     forEach(browsersToSupport, (versions, browserName) => {
+                        if (browserName !== browserToSupportName) {
+                            return;
+                        }
+
                         versions.forEach((version) => {
-                            if (version <= removedVersionNumber) {
+                            if (version < removedVersionNumber) {
                                 return;
                             }
 

--- a/packages/hint-compat-api/src/compat-api-css.ts
+++ b/packages/hint-compat-api/src/compat-api-css.ts
@@ -121,7 +121,7 @@ export default class implements IHint {
                     },
 
                     testFeature: (node: Rule, data, browsers) => {
-                        // checkDeprecatedCSSFeature('at-rules', node.selector, data, browsers);
+                        checkDeprecatedCSSFeature('selectors', node.selector, data, browsers);
                     }
                 };
 
@@ -131,7 +131,7 @@ export default class implements IHint {
                     },
 
                     testFeature: (node: Declaration, data, browsers) => {
-                        // checkDeprecatedCSSFeature('at-rules', node.value, data, browsers);
+                        checkDeprecatedCSSFeature('properties', node.prop, data, browsers);
                     }
                 };
 

--- a/packages/hint-compat-api/src/helpers/compat-api.ts
+++ b/packages/hint-compat-api/src/helpers/compat-api.ts
@@ -54,6 +54,10 @@ export class CompatApi {
             return currentBrowserFeatureSupported;
         }
 
+        if (!Array.isArray(currentBrowserFeatureSupported) && currentBrowserFeatureSupported.prefix && currentBrowserFeatureSupported.prefix !== prefix) {
+            return undefined;
+        }
+
         // Sometimes the API give an array but only the first seems relevant
         if (Array.isArray(currentBrowserFeatureSupported) && currentBrowserFeatureSupported.length > 0) {
             if (prefix) {

--- a/packages/hint-compat-api/src/helpers/compat-api.ts
+++ b/packages/hint-compat-api/src/helpers/compat-api.ts
@@ -40,48 +40,51 @@ export class CompatApi {
     }
 
     public getPrefix(name: string): [string, string] | [undefined, string] {
-        const regexp = new RegExp(`\-(moz|o|webkit|ms)\-`, 'gi');
+        const regexp = new RegExp(`-(moz|o|webkit|ms)-`, 'gi');
         const matched = name.match(regexp);
 
         return matched && matched.length > 0 ? [matched[0], name.replace(matched[0], '')] : [undefined, name];
     }
 
     public getSupportStatementFromInfo(browserFeatureSupported: SupportStatement | undefined, prefix: string | undefined): SimpleSupportStatement | undefined {
+        let currentBrowserFeatureSupported = browserFeatureSupported;
+
         // If we dont have information about the compatibility, ignore.
-        if (!browserFeatureSupported) {
-            return;
+        if (!currentBrowserFeatureSupported) {
+            return currentBrowserFeatureSupported;
         }
 
         // Sometimes the API give an array but only the first seems relevant
-        if (Array.isArray(browserFeatureSupported) && browserFeatureSupported.length > 0) {
+        if (Array.isArray(currentBrowserFeatureSupported) && currentBrowserFeatureSupported.length > 0) {
             if (prefix) {
-                browserFeatureSupported = browserFeatureSupported.find(info => {
+                currentBrowserFeatureSupported = currentBrowserFeatureSupported.find((info) => {
                     return info.prefix === prefix;
                 });
             } else {
-                browserFeatureSupported = browserFeatureSupported.find(info => {
+                currentBrowserFeatureSupported = currentBrowserFeatureSupported.find((info) => {
                     return !info.prefix;
                 });
             }
         }
 
-        return browserFeatureSupported as SimpleSupportStatement;
+        return currentBrowserFeatureSupported as SimpleSupportStatement;
     }
 
+    /* eslint-disable camelcase */
     public getWorstCaseSupportStatementFromInfo(browserFeatureSupported: SupportStatement | undefined): SimpleSupportStatement | undefined {
         // If we dont have information about the compatibility, ignore.
         if (!browserFeatureSupported) {
-            return;
+            return browserFeatureSupported;
         }
 
         // Take the smaller version_removed and bigger version_added
-        let worstBrowserFeatureSupported: SimpleSupportStatement = {
+        const worstBrowserFeatureSupported: SimpleSupportStatement = {
             version_added: null,
             version_removed: null
         };
 
         if (Array.isArray(browserFeatureSupported) && browserFeatureSupported.length > 0) {
-            browserFeatureSupported.forEach(info => {
+            browserFeatureSupported.forEach((info) => {
                 if (!worstBrowserFeatureSupported.version_added && info.version_added === true) {
                     worstBrowserFeatureSupported.version_added = true;
                 }
@@ -90,7 +93,7 @@ export class CompatApi {
                     worstBrowserFeatureSupported.version_added = info.version_added;
                 }
 
-                if (!worstBrowserFeatureSupported.version_removed &&  info.version_removed === true) {
+                if (!worstBrowserFeatureSupported.version_removed && info.version_removed === true) {
                     worstBrowserFeatureSupported.version_removed = true;
                 }
 
@@ -99,12 +102,12 @@ export class CompatApi {
                 }
             });
 
-
             return worstBrowserFeatureSupported;
         }
 
         return browserFeatureSupported as SimpleSupportStatement;
     }
+    /* eslint-enable camelcase */
 
     private isFeatureRequiredToTest(typedFeatureValue: CompatStatement & MDNTreeFilteredByBrowsers, isCheckingNotBroadlySupported = false): boolean {
         // TODO: Here we are checking only parent but this object has children
@@ -115,7 +118,7 @@ export class CompatApi {
                 return;
             }
 
-            let browserFeatureSupported = this.getWorstCaseSupportStatementFromInfo((typedFeatureValue.__compat.support as any)[browser]);
+            const browserFeatureSupported = this.getWorstCaseSupportStatementFromInfo((typedFeatureValue.__compat.support as any)[browser]);
 
             // If we dont have information about the compatibility, ignore.
             if (!browserFeatureSupported) {

--- a/packages/hint-compat-api/src/helpers/compat-api.ts
+++ b/packages/hint-compat-api/src/helpers/compat-api.ts
@@ -2,14 +2,14 @@
 const bcd: CompatData = require('mdn-browser-compat-data');
 
 import { forEach } from 'lodash';
-import { BrowserSupportCollection } from '../types';
-import { CompatData, Identifier, CompatStatement } from '../types-mdn.temp'; // Temporal
+import { BrowserSupportCollection, MDNTreeFilteredByBrowsers } from '../types';
+import { CompatData, CompatStatement } from '../types-mdn.temp'; // Temporal
 import { isArray } from 'util';
 
 type CompatNamespace = 'css' | 'javascript' | 'html';
 
 export class CompatApi {
-    private compatDataApi: Identifier; // Any because no types by the moment, check line 1
+    public compatDataApi: MDNTreeFilteredByBrowsers; // Any because no types by the moment, check line 1
     private browsers: BrowserSupportCollection;
 
     public constructor(namespaceName: CompatNamespace, browsers: BrowserSupportCollection, isCheckingNotBroadlySupported = false) {
@@ -19,13 +19,13 @@ export class CompatApi {
     }
 
     private applyBrowsersConfiguration(isCheckingNotBroadlySupported = false): any {
-        const compatDataApi = {} as Identifier;
+        const compatDataApi = {} as MDNTreeFilteredByBrowsers;
 
         forEach(this.compatDataApi, (groupFeaturesValues, groupFeaturesKey) => {
-            const groupFeatures = {} as CompatStatement & Identifier;
+            const groupFeatures = {} as CompatStatement & MDNTreeFilteredByBrowsers;
 
             forEach(groupFeaturesValues, (featureValue, featureKey) => {
-                const typedFeatureValue = featureValue as CompatStatement & Identifier;
+                const typedFeatureValue = featureValue as CompatStatement & MDNTreeFilteredByBrowsers;
 
                 if (!this.isFeatureRequiredToTest(typedFeatureValue, isCheckingNotBroadlySupported)) {
                     return;
@@ -40,7 +40,7 @@ export class CompatApi {
         return compatDataApi;
     }
 
-    private isFeatureRequiredToTest(typedFeatureValue: CompatStatement & Identifier, isCheckingNotBroadlySupported = false): boolean {
+    private isFeatureRequiredToTest(typedFeatureValue: CompatStatement & MDNTreeFilteredByBrowsers, isCheckingNotBroadlySupported = false): boolean {
         // TODO: Here we are checking only parent but this object has children
         let isRequiredToTest = false;
 

--- a/packages/hint-compat-api/src/helpers/convert-browser-names.ts
+++ b/packages/hint-compat-api/src/helpers/convert-browser-names.ts
@@ -1,4 +1,4 @@
-import { BrowserSupportCollection, BrowserSupportCollectionRaw } from '../types';
+import { BrowserSupportCollection } from '../types';
 
 type BrowsersDictionary = {
     [key: string]: string;
@@ -31,7 +31,7 @@ const browserNamesToMDN: BrowsersDictionary = {
 };
 /* eslint-enable */
 
-export const convertBrowserSupportCollectionToMDN = (browserCollection: BrowserSupportCollectionRaw): BrowserSupportCollection => {
+export const convertBrowserSupportCollectionToMDN = (browserCollection: BrowserSupportCollection): BrowserSupportCollection => {
     const mdnCollection = {} as BrowserSupportCollection;
 
     Object.entries(browserCollection).forEach(([browserName, browserVersions]) => {
@@ -43,11 +43,7 @@ export const convertBrowserSupportCollectionToMDN = (browserCollection: BrowserS
 
         mdnCollection[mdnName] = mdnCollection[mdnName] || [];
 
-        const mdnVersions = browserVersions.map((x: string) => {
-            return Number(x);
-        });
-
-        mdnCollection[mdnName] = ([...mdnCollection[mdnName], ...mdnVersions]).sort((a, b) => {
+        mdnCollection[mdnName] = ([...mdnCollection[mdnName], ...browserVersions]).sort((a, b) => {
             return a - b;
         });
     });

--- a/packages/hint-compat-api/src/helpers/get-user-browsers.ts
+++ b/packages/hint-compat-api/src/helpers/get-user-browsers.ts
@@ -1,9 +1,10 @@
-import { BrowserSupportCollection, BrowserSupportCollectionRaw } from '../types';
+import { BrowserSupportCollection } from '../types';
 import { convertBrowserSupportCollectionToMDN } from '.';
+import { browserVersions } from './normalize-version';
 
 class UserBrowsers {
     public convert(targetedBrowsers: string[]): BrowserSupportCollection {
-        const browserCollection = {} as BrowserSupportCollectionRaw;
+        const browserCollection = {} as BrowserSupportCollection;
 
         targetedBrowsers.forEach((browserInfo: string) => {
             const [browserName, browserVersion] = browserInfo.split(' ');
@@ -15,15 +16,15 @@ class UserBrowsers {
         return convertBrowserSupportCollectionToMDN(browserCollection);
     }
 
-    private getBrowserVersions(version: string): string[] {
+    private getBrowserVersions(version: string): number[] {
         // We support to have two versions in same targeted browser
         if (version.match(/-/)) {
             const [first, second] = version.split('-');
 
-            return [first, second];
+            return [browserVersions.normalize(first), browserVersions.normalize(second)];
         }
 
-        return [version];
+        return [browserVersions.normalize(version)];
     }
 }
 

--- a/packages/hint-compat-api/src/helpers/normalize-version.ts
+++ b/packages/hint-compat-api/src/helpers/normalize-version.ts
@@ -1,0 +1,46 @@
+import { padStart, padEnd } from 'lodash';
+
+// Normalize versions because https://github.com/mdn/browser-compat-data/pull/2690#issuecomment-417237045
+class BrowserVersions {
+    private columnSeparator = '.';
+    private charForPad = '0';
+    private itemsInColum = 2; // Assuming that worst case is xx.xx.xx
+    private columns = 3;
+    private itemsInColumns = this.itemsInColum * this.columns;
+
+    public normalize(browserVersion: string): number {
+        const result = browserVersion.split(this.columnSeparator).map(column => {
+            return padStart(column, this.itemsInColum, this.charForPad);
+        }).join('');
+
+        return Number(padEnd(result, this.itemsInColumns, this.charForPad))
+    }
+
+    public deNormalize(normalizedVersion: number): string {
+        const normalizedVersionString = padStart(normalizedVersion + '', this.itemsInColumns, this.charForPad);
+        const columns = normalizedVersionString.match(/..?/g);
+
+        if (!columns) {
+            throw new Error(`Value ${normalizedVersion} is not allowed to be denormalized.`);
+        }
+
+        let realNumbers: number[] = [];
+        let foundNumberGreaterThanZero = false;
+        columns.reverse().forEach(items => {
+            const converted = Number(items);
+            if (converted === 0 && !foundNumberGreaterThanZero) {
+              return;
+            }
+
+            if (converted > 0) {
+              foundNumberGreaterThanZero = true;
+            }
+
+            realNumbers.push(converted);
+        });
+
+        return realNumbers.reverse().join('.');
+    }
+}
+
+export const browserVersions = new BrowserVersions();

--- a/packages/hint-compat-api/src/helpers/normalize-version.ts
+++ b/packages/hint-compat-api/src/helpers/normalize-version.ts
@@ -5,8 +5,7 @@ class BrowserVersions {
     private columnSeparator = '.';
     private charForPad = '0';
     private itemsInColum = 2; // Assuming that worst case is xx.xx.xx
-    private columns = 3;
-    private itemsInColumns = this.itemsInColum * this.columns;
+    private itemsInColumns = 6;
 
     public normalize(browserVersion: string): number {
         const result = browserVersion.split(this.columnSeparator).map(column => {

--- a/packages/hint-compat-api/src/helpers/normalize-version.ts
+++ b/packages/hint-compat-api/src/helpers/normalize-version.ts
@@ -8,31 +8,34 @@ class BrowserVersions {
     private itemsInColumns = 6;
 
     public normalize(browserVersion: string): number {
-        const result = browserVersion.split(this.columnSeparator).map(column => {
+        const result = browserVersion.split(this.columnSeparator).map((column) => {
             return padStart(column, this.itemsInColum, this.charForPad);
-        }).join('');
+        })
+            .join('');
 
-        return Number(padEnd(result, this.itemsInColumns, this.charForPad))
+        return Number(padEnd(result, this.itemsInColumns, this.charForPad));
     }
 
     public deNormalize(normalizedVersion: number): string {
-        const normalizedVersionString = padStart(normalizedVersion + '', this.itemsInColumns, this.charForPad);
+        const normalizedVersionString = padStart(`${normalizedVersion}`, this.itemsInColumns, this.charForPad);
         const columns = normalizedVersionString.match(/..?/g);
 
         if (!columns) {
             throw new Error(`Value ${normalizedVersion} is not allowed to be denormalized.`);
         }
 
-        let realNumbers: number[] = [];
+        const realNumbers: number[] = [];
         let foundNumberGreaterThanZero = false;
-        columns.reverse().forEach(items => {
+
+        columns.reverse().forEach((items) => {
             const converted = Number(items);
+
             if (converted === 0 && !foundNumberGreaterThanZero) {
-              return;
+                return;
             }
 
             if (converted > 0) {
-              foundNumberGreaterThanZero = true;
+                foundNumberGreaterThanZero = true;
             }
 
             realNumbers.push(converted);

--- a/packages/hint-compat-api/src/types-mdn.temp.ts
+++ b/packages/hint-compat-api/src/types-mdn.temp.ts
@@ -29,13 +29,13 @@ type BrowserNames =
  * It is an array of `simple_support_statement` objects, but if there
  * is only one of them, the array must be omitted.
  */
-type SupportStatement = SimpleSupportStatement | SimpleSupportStatement[];
+export type SupportStatement = SimpleSupportStatement | SimpleSupportStatement[];
 type VersionValue = string | boolean | null;
 
 /**
  * The `simple_support_statement` object is the core object containing the compatibility information for a browser.
  */
-interface SimpleSupportStatement {
+export interface SimpleSupportStatement {
   /** The version indicating when a sub-feature has been added (and is therefore supported).
    *
    * The `boolean` values indicate that a sub-feature is supported

--- a/packages/hint-compat-api/src/types.ts
+++ b/packages/hint-compat-api/src/types.ts
@@ -1,7 +1,14 @@
+import { ChildNode } from 'postcss';
+
 export type BrowserSupportCollection = {
     [key: string]: number[];
 };
 
 export type BrowserSupportCollectionRaw = {
     [key: string]: string[];
+};
+
+export type FeatureStrategy<T extends ChildNode> = {
+    testFeature: (node: T | ChildNode) => void;
+    check: (node: T | ChildNode) => boolean;
 };

--- a/packages/hint-compat-api/src/types.ts
+++ b/packages/hint-compat-api/src/types.ts
@@ -7,10 +7,6 @@ export type BrowserSupportCollection = {
     [key: string]: number[];
 };
 
-export type BrowserSupportCollectionRaw = {
-    [key: string]: string[];
-};
-
 export type FeatureStrategy<T extends ChildNode> = {
     check: (node: T | ChildNode) => boolean;
     testFeature: (node: T, data: MDNTreeFilteredByBrowsers, browsers: BrowserSupportCollection) => void;

--- a/packages/hint-compat-api/src/types.ts
+++ b/packages/hint-compat-api/src/types.ts
@@ -1,4 +1,7 @@
 import { ChildNode } from 'postcss';
+import { Identifier } from './types-mdn.temp'; // Temporal
+
+export type MDNTreeFilteredByBrowsers = Identifier;
 
 export type BrowserSupportCollection = {
     [key: string]: number[];
@@ -9,6 +12,6 @@ export type BrowserSupportCollectionRaw = {
 };
 
 export type FeatureStrategy<T extends ChildNode> = {
-    testFeature: (node: T | ChildNode) => void;
     check: (node: T | ChildNode) => boolean;
+    testFeature: (node: T, data: MDNTreeFilteredByBrowsers, browsers: BrowserSupportCollection) => void;
 };

--- a/packages/hint-compat-api/tests/compat-api-css.ts
+++ b/packages/hint-compat-api/tests/compat-api-css.ts
@@ -29,8 +29,8 @@ const tests: Array<HintTest> = [
     {
         name: 'This test should pass',
         // reports: [{ message: 'text' }],
-        serverConfig: generateCSSConfig('keyframes')
+        serverConfig: generateCSSConfig('box-line')
     }
 ];
 
-hintRunner.testHint(hintPath, tests, { browserslist: ['last 2 versions'], parsers: ['css']});
+hintRunner.testHint(hintPath, tests, { browserslist: ['chrome 64-67'], parsers: ['css']});

--- a/packages/hint-compat-api/tests/compat-api-css.ts
+++ b/packages/hint-compat-api/tests/compat-api-css.ts
@@ -1,9 +1,23 @@
-import generateHTMLPage from 'hint/dist/src/lib/utils/misc/generate-html-page';
 import { getHintPath } from 'hint/dist/src/lib/utils/hint-helpers';
 import { HintTest } from '@hint/utils-tests-helpers/dist/src/hint-test-type';
+import generateHTMLPage from 'hint/dist/src/lib/utils/misc/generate-html-page';
+import readFile from 'hint/dist/src/lib/utils/fs/read-file';
 import * as hintRunner from '@hint/utils-tests-helpers/dist/src/hint-runner';
 
 const hintPath = getHintPath(__filename, true);
+
+const generateCSSConfig = (fileName: string) => {
+    const path = 'fixtures/css';
+    const styles = readFile(`${__dirname}/${path}/${fileName}.css`);
+
+    return {
+        '/': generateHTMLPage('<link rel="stylesheet" href="styles">'),
+        '/styles': {
+            content: styles,
+            headers: { 'Content-Type': 'text/css' }
+        }
+    }
+};
 
 /*
  * You should test for cases where the hint passes and doesn't.
@@ -14,8 +28,9 @@ const hintPath = getHintPath(__filename, true);
 const tests: Array<HintTest> = [
     {
         name: 'This test should pass',
-        serverConfig: generateHTMLPage()
+        // reports: [{ message: 'text' }],
+        serverConfig: generateCSSConfig('keyframes')
     }
 ];
 
-hintRunner.testHint(hintPath, tests);
+hintRunner.testHint(hintPath, tests, { parsers: ['css'], browserslist: ['last 2 versions']});

--- a/packages/hint-compat-api/tests/compat-api-css.ts
+++ b/packages/hint-compat-api/tests/compat-api-css.ts
@@ -16,7 +16,7 @@ const generateCSSConfig = (fileName: string) => {
             content: styles,
             headers: { 'Content-Type': 'text/css' }
         }
-    }
+    };
 };
 
 /*
@@ -33,4 +33,4 @@ const tests: Array<HintTest> = [
     }
 ];
 
-hintRunner.testHint(hintPath, tests, { parsers: ['css'], browserslist: ['last 2 versions']});
+hintRunner.testHint(hintPath, tests, { browserslist: ['last 2 versions'], parsers: ['css']});

--- a/packages/hint-compat-api/tests/compat-api-css.ts
+++ b/packages/hint-compat-api/tests/compat-api-css.ts
@@ -33,4 +33,4 @@ const tests: Array<HintTest> = [
     }
 ];
 
-hintRunner.testHint(hintPath, tests, { browserslist: ['chrome 64-67'], parsers: ['css']});
+hintRunner.testHint(hintPath, tests, { browserslist: ['chrome 64-69'], parsers: ['css']});

--- a/packages/hint-compat-api/tests/fixtures/css/box-line.css
+++ b/packages/hint-compat-api/tests/fixtures/css/box-line.css
@@ -1,0 +1,4 @@
+.example {
+    box-lines: single;
+    -webkit-box-lines: single;
+}

--- a/packages/hint-compat-api/tests/fixtures/css/keyframes.css
+++ b/packages/hint-compat-api/tests/fixtures/css/keyframes.css
@@ -1,0 +1,11 @@
+@keyframes name {
+    0% {
+        left: 0%;
+    }
+}
+
+@-webkit-keyframes name {
+    0% {
+        left: 0%;
+    }
+}


### PR DESCRIPTION
This applies to:

https://github.com/mdn/browser-compat-data/issues/3034
https://github.com/webhintio/hint/pull/1443