### PR TITLE
Refactor compat api css

### DIFF
--- a/packages/hint-compat-api/src/compat-api-css-base.ts
+++ b/packages/hint-compat-api/src/compat-api-css-base.ts
@@ -28,8 +28,8 @@ export default abstract class BaseCompatApiCSS implements IHint {
     private statusName: CSSFeatureStatus;
 
     abstract getFeatureVersionValueToAnalyze(browserFeatureSupported: SimpleSupportStatement): VersionValue;
-    abstract isVersionFeatureSupported(version: VersionValue): boolean;
-    abstract isVersionTestable(version: VersionValue): boolean;
+    abstract isVersionValueSupported(version: VersionValue): boolean;
+    abstract isVersionValueTestable(version: VersionValue): boolean;
     abstract isSupportedVersion(currentVersion: number, version: number): boolean;
 
     public constructor(context: HintContext<StyleEvents>, statusName: CSSFeatureStatus, isCheckingNotBroadlySupported?: boolean) {
@@ -62,8 +62,8 @@ export default abstract class BaseCompatApiCSS implements IHint {
         if (browserFeatureSupported) {
             const version = this.getFeatureVersionValueToAnalyze(browserFeatureSupported);
 
-            if (this.isVersionTestable(version)) {
-                if (this.isVersionFeatureSupported(version)) {
+            if (this.isVersionValueTestable(version)) {
+                if (this.isVersionValueSupported(version)) {
                     await this.testNotSupportedVersionsByBrowsers(browsersToSupport, version as string, browserToSupportName, featureName, location, prefix);
                 } else {
                     const message = `${featureName} of CSS is not supported on ${browserToSupportName} browser.`;

--- a/packages/hint-compat-api/src/compat-api-css-base.ts
+++ b/packages/hint-compat-api/src/compat-api-css-base.ts
@@ -1,0 +1,104 @@
+/**
+ * @fileoverview Hint to validate if the CSS features of the project are deprecated
+ */
+
+import { HintContext } from 'hint/dist/src/lib/hint-context';
+import { IHint, ProblemLocation } from 'hint/dist/src/lib/types';
+import { StyleParse, StyleEvents } from '@hint/parser-css/dist/src/types';
+import { CompatApi, userBrowsers, CompatCSS } from './helpers';
+import { BrowserSupportCollection } from './types';
+import { SimpleSupportStatement, SupportStatement, VersionValue } from './types-mdn.temp';
+
+import meta from './meta/compat-api-css';
+import { browserVersions } from './helpers/normalize-version';
+import { CSSFeatureStatus } from './enums';
+
+/*
+ * ------------------------------------------------------------------------------
+ * Public
+ * ------------------------------------------------------------------------------
+ */
+
+export default abstract class BaseCompatApiCSS implements IHint {
+    public static readonly meta = meta;
+
+    private mdnBrowsersCollection: BrowserSupportCollection;
+    private compatApi: CompatApi;
+    private compatCSS: CompatCSS;
+
+    abstract getFeatureVersionValueToAnalyze(browserFeatureSupported: SimpleSupportStatement): VersionValue;
+    abstract isVersionFeatureSupported(version: VersionValue): boolean;
+    abstract isVersionTestable(version: VersionValue): boolean;
+    abstract isSupportedVersion(currentVersion: number, version: number): boolean;
+
+    public constructor(context: HintContext<StyleEvents>, private statusName: CSSFeatureStatus, isCheckingNotBroadlySupported?: boolean) {
+        this.mdnBrowsersCollection = userBrowsers.convert(context.targetedBrowsers);
+        this.compatApi = new CompatApi('css', this.mdnBrowsersCollection, isCheckingNotBroadlySupported);
+        this.compatCSS = new CompatCSS(context, (...params) => {
+            this.testFeatureIsSupportedInBrowser(...params);
+        });
+        
+        context.on('parse::end::css', async (styleParse: StyleParse) => {
+            await this.onParseCSS(styleParse);
+        });
+    }
+
+    private async onParseCSS(styleParse: StyleParse): Promise<void> {
+        const { resource } = styleParse;
+
+        this.compatCSS.setResource(resource);
+        await this.compatCSS.searchCSSFeatures(this.compatApi.compatDataApi, this.mdnBrowsersCollection, styleParse);
+    }
+
+    private async testFeatureIsSupportedInBrowser(browsersToSupport: BrowserSupportCollection, browserToSupportName: string, browserInfo: SupportStatement, featureName: string, prefix?: string, location?: ProblemLocation): Promise<void> {
+        if (!this.compatApi.isBrowserToSupportPartOfBrowsersCollection(browsersToSupport, browserToSupportName)) {
+            return;
+        }
+
+        const browserFeatureSupported = this.compatApi.getSupportStatementFromInfo(browserInfo, prefix);
+
+        if (browserFeatureSupported) {
+            const version = this.getFeatureVersionValueToAnalyze(browserFeatureSupported);
+
+            if (this.isVersionTestable(version)) {
+                if (this.isVersionFeatureSupported(version)) {
+                    await this.testNotSupportedVersionsByBrowsers(browsersToSupport, version as string, browserToSupportName, featureName, location, prefix);
+                } else {
+                    const message = `${featureName} of CSS is not supported on ${browserToSupportName} browser.`;
+
+                    await this.compatCSS.reportError(featureName, message, location);
+                }
+            }
+
+        } else {
+            const message = `${featureName} of CSS was never supported on any of your browsers to support.`;
+
+            await this.compatCSS.reportIfThereIsNoInformationAboutCompatibility(message, browsersToSupport, browserToSupportName, featureName, location);
+        }
+    }
+
+    protected async testNotSupportedVersionsByBrowsers(browsersToSupport: BrowserSupportCollection, version: string, browserToSupportName: string, featureName: string, location?: ProblemLocation, prefix?: string): Promise<void> {
+        const versionNumber = browserVersions.normalize(version);
+        const notSupportedVersions: number[] = this.getNotSupportedVersions(browsersToSupport, browserToSupportName, versionNumber);
+
+        if (notSupportedVersions.length === 0) {
+            return;
+        }
+
+        const formattedNotSupportedVersions: string[] = this.formatNotSupportedVersions(browserToSupportName, notSupportedVersions);
+        const message = this.compatCSS.generateNotSupportedVersionsError(featureName, formattedNotSupportedVersions, this.statusName, prefix);
+
+        await this.compatCSS.reportError(featureName, message, location);
+    }
+
+    private getNotSupportedVersions(browsersToSupport: BrowserSupportCollection, browserToSupportName: string, currentVersion: number): number[] {
+        const isBrowserDefined: boolean = !!browsersToSupport[browserToSupportName];
+        const versions: number[] = isBrowserDefined ? browsersToSupport[browserToSupportName] : [];
+
+        return versions.filter((version: number) => !this.isSupportedVersion(currentVersion, version));
+    }
+
+    private formatNotSupportedVersions(browserName: string, versions: number[]): string[] {
+        return versions.map((version: number) => `${browserName} ${browserVersions.deNormalize(version)}`);
+    }
+}

--- a/packages/hint-compat-api/src/compat-api-css-base.ts
+++ b/packages/hint-compat-api/src/compat-api-css-base.ts
@@ -6,7 +6,7 @@ import { HintContext } from 'hint/dist/src/lib/hint-context';
 import { IHint } from 'hint/dist/src/lib/types';
 import { StyleParse, StyleEvents } from '@hint/parser-css/dist/src/types';
 import { CompatApi, userBrowsers, CompatCSS } from './helpers';
-import { BrowserSupportCollection, FeatureInfo, BrowserInfo } from './types';
+import { BrowserSupportCollection, FeatureInfo, BrowsersInfo } from './types';
 import { SimpleSupportStatement, VersionValue } from './types-mdn.temp';
 
 import meta from './meta/compat-api-css';
@@ -27,9 +27,9 @@ export default abstract class BaseCompatApiCSS implements IHint {
     private compatCSS: CompatCSS;
 
     abstract getFeatureVersionValueToAnalyze(browserFeatureSupported: SimpleSupportStatement): VersionValue;
+    abstract isSupportedVersion(currentVersion: number, version: number): boolean;
     abstract isVersionValueSupported(version: VersionValue): boolean;
     abstract isVersionValueTestable(version: VersionValue): boolean;
-    abstract isSupportedVersion(currentVersion: number, version: number): boolean;
     abstract getStatusNameValue(): CSSFeatureStatus;
 
     public constructor(context: HintContext<StyleEvents>, isCheckingNotBroadlySupported: boolean) {
@@ -49,7 +49,7 @@ export default abstract class BaseCompatApiCSS implements IHint {
         await this.compatCSS.searchCSSFeatures(this.compatApi.compatDataApi, this.mdnBrowsersCollection, styleParse);
     }
 
-    private async testFeatureIsSupportedInBrowser(browser: BrowserInfo, feature: FeatureInfo): Promise<void> {
+    private async testFeatureIsSupportedInBrowser(browser: BrowsersInfo, feature: FeatureInfo): Promise<void> {
         if (!this.compatApi.isBrowserToSupportPartOfBrowsersCollection(browser.browsersToSupport, browser.browserToSupportName)) {
             return;
         }
@@ -65,7 +65,7 @@ export default abstract class BaseCompatApiCSS implements IHint {
         }
     }
 
-    private async testVersionByBrowsers(browser: BrowserInfo, browserFeatureSupported: SimpleSupportStatement, feature: FeatureInfo) {
+    private async testVersionByBrowsers(browser: BrowsersInfo, browserFeatureSupported: SimpleSupportStatement, feature: FeatureInfo) {
         const version = this.getFeatureVersionValueToAnalyze(browserFeatureSupported);
 
         if (!this.isVersionValueTestable(version)) {
@@ -81,7 +81,7 @@ export default abstract class BaseCompatApiCSS implements IHint {
         }
     }
 
-    protected async testNotSupportedVersionsByBrowsers(browser: BrowserInfo, feature: FeatureInfo, version: string): Promise<void> {
+    protected async testNotSupportedVersionsByBrowsers(browser: BrowsersInfo, feature: FeatureInfo, version: string): Promise<void> {
         const versionNumber = browserVersions.normalize(version);
         const notSupportedVersions: number[] = this.getNotSupportedVersions(browser, versionNumber);
 
@@ -96,7 +96,7 @@ export default abstract class BaseCompatApiCSS implements IHint {
         await this.compatCSS.reportError(feature.featureName, message, feature.location);
     }
 
-    private getNotSupportedVersions(browser: BrowserInfo, currentVersion: number): number[] {
+    private getNotSupportedVersions(browser: BrowsersInfo, currentVersion: number): number[] {
         const isBrowserDefined: boolean = !!browser.browsersToSupport[browser.browserToSupportName];
         const versions: number[] = isBrowserDefined ? browser.browsersToSupport[browser.browserToSupportName] : [];
 

--- a/packages/hint-compat-api/src/compat-api-css-base.ts
+++ b/packages/hint-compat-api/src/compat-api-css-base.ts
@@ -25,19 +25,21 @@ export default abstract class BaseCompatApiCSS implements IHint {
     private mdnBrowsersCollection: BrowserSupportCollection;
     private compatApi: CompatApi;
     private compatCSS: CompatCSS;
+    private statusName: CSSFeatureStatus;
 
     abstract getFeatureVersionValueToAnalyze(browserFeatureSupported: SimpleSupportStatement): VersionValue;
     abstract isVersionFeatureSupported(version: VersionValue): boolean;
     abstract isVersionTestable(version: VersionValue): boolean;
     abstract isSupportedVersion(currentVersion: number, version: number): boolean;
 
-    public constructor(context: HintContext<StyleEvents>, private statusName: CSSFeatureStatus, isCheckingNotBroadlySupported?: boolean) {
+    public constructor(context: HintContext<StyleEvents>, statusName: CSSFeatureStatus, isCheckingNotBroadlySupported?: boolean) {
+        this.statusName = statusName;
         this.mdnBrowsersCollection = userBrowsers.convert(context.targetedBrowsers);
         this.compatApi = new CompatApi('css', this.mdnBrowsersCollection, isCheckingNotBroadlySupported);
         this.compatCSS = new CompatCSS(context, (...params) => {
             this.testFeatureIsSupportedInBrowser(...params);
         });
-        
+
         context.on('parse::end::css', async (styleParse: StyleParse) => {
             await this.onParseCSS(styleParse);
         });
@@ -95,10 +97,14 @@ export default abstract class BaseCompatApiCSS implements IHint {
         const isBrowserDefined: boolean = !!browsersToSupport[browserToSupportName];
         const versions: number[] = isBrowserDefined ? browsersToSupport[browserToSupportName] : [];
 
-        return versions.filter((version: number) => !this.isSupportedVersion(currentVersion, version));
+        return versions.filter((version: number) => {
+            return !this.isSupportedVersion(currentVersion, version);
+        });
     }
 
     private formatNotSupportedVersions(browserName: string, versions: number[]): string[] {
-        return versions.map((version: number) => `${browserName} ${browserVersions.deNormalize(version)}`);
+        return versions.map((version: number) => {
+            return `${browserName} ${browserVersions.deNormalize(version)}`;
+        });
     }
 }

--- a/packages/hint-compat-api/src/compat-api-css-base.ts
+++ b/packages/hint-compat-api/src/compat-api-css-base.ts
@@ -25,15 +25,14 @@ export default abstract class BaseCompatApiCSS implements IHint {
     private mdnBrowsersCollection: BrowserSupportCollection;
     private compatApi: CompatApi;
     private compatCSS: CompatCSS;
-    private statusName: CSSFeatureStatus;
 
     abstract getFeatureVersionValueToAnalyze(browserFeatureSupported: SimpleSupportStatement): VersionValue;
     abstract isVersionValueSupported(version: VersionValue): boolean;
     abstract isVersionValueTestable(version: VersionValue): boolean;
     abstract isSupportedVersion(currentVersion: number, version: number): boolean;
+    abstract getStatusNameValue(): CSSFeatureStatus;
 
-    public constructor(context: HintContext<StyleEvents>, statusName: CSSFeatureStatus, isCheckingNotBroadlySupported?: boolean) {
-        this.statusName = statusName;
+    public constructor(context: HintContext<StyleEvents>, isCheckingNotBroadlySupported: boolean) {
         this.mdnBrowsersCollection = userBrowsers.convert(context.targetedBrowsers);
         this.compatApi = new CompatApi('css', this.mdnBrowsersCollection, isCheckingNotBroadlySupported);
         this.compatCSS = new CompatCSS(context, this.testFeatureIsSupportedInBrowser.bind(this));
@@ -90,8 +89,9 @@ export default abstract class BaseCompatApiCSS implements IHint {
             return;
         }
 
+        const statusName = this.getStatusNameValue();
         const formattedNotSupportedVersions: string[] = this.formatNotSupportedVersions(browser.browserToSupportName, notSupportedVersions);
-        const message = this.compatCSS.generateNotSupportedVersionsError(feature.featureName, formattedNotSupportedVersions, this.statusName, feature.prefix);
+        const message = this.compatCSS.generateNotSupportedVersionsError(feature.featureName, formattedNotSupportedVersions, statusName, feature.prefix);
 
         await this.compatCSS.reportError(feature.featureName, message, feature.location);
     }

--- a/packages/hint-compat-api/src/compat-api-css-base.ts
+++ b/packages/hint-compat-api/src/compat-api-css-base.ts
@@ -60,22 +60,27 @@ export default abstract class BaseCompatApiCSS implements IHint {
         const browserFeatureSupported = this.compatApi.getSupportStatementFromInfo(browserInfo, prefix);
 
         if (browserFeatureSupported) {
-            const version = this.getFeatureVersionValueToAnalyze(browserFeatureSupported);
-
-            if (this.isVersionValueTestable(version)) {
-                if (this.isVersionValueSupported(version)) {
-                    await this.testNotSupportedVersionsByBrowsers(browsersToSupport, version as string, browserToSupportName, featureName, location, prefix);
-                } else {
-                    const message = `${featureName} of CSS is not supported on ${browserToSupportName} browser.`;
-
-                    await this.compatCSS.reportError(featureName, message, location);
-                }
-            }
-
+            this.testVersionByBrowsers(browsersToSupport, browserFeatureSupported, browserToSupportName, browserInfo, featureName, prefix, location);
         } else {
             const message = `${featureName} of CSS was never supported on any of your browsers to support.`;
 
             await this.compatCSS.reportIfThereIsNoInformationAboutCompatibility(message, browsersToSupport, browserToSupportName, featureName, location);
+        }
+    }
+
+    private async testVersionByBrowsers(browsersToSupport: BrowserSupportCollection, browserFeatureSupported: SimpleSupportStatement, browserToSupportName: string, browserInfo: SupportStatement, featureName: string, prefix?: string, location?: ProblemLocation) {
+        const version = this.getFeatureVersionValueToAnalyze(browserFeatureSupported);
+
+        if (!this.isVersionValueTestable(version)) {
+            return;
+        }
+
+        if (this.isVersionValueSupported(version)) {
+            await this.testNotSupportedVersionsByBrowsers(browsersToSupport, version as string, browserToSupportName, featureName, location, prefix);
+        } else {
+            const message = `${featureName} of CSS is not supported on ${browserToSupportName} browser.`;
+
+            await this.compatCSS.reportError(featureName, message, location);
         }
     }
 

--- a/packages/hint-compat-api/src/compat-api-css-base.ts
+++ b/packages/hint-compat-api/src/compat-api-css-base.ts
@@ -36,9 +36,7 @@ export default abstract class BaseCompatApiCSS implements IHint {
         this.statusName = statusName;
         this.mdnBrowsersCollection = userBrowsers.convert(context.targetedBrowsers);
         this.compatApi = new CompatApi('css', this.mdnBrowsersCollection, isCheckingNotBroadlySupported);
-        this.compatCSS = new CompatCSS(context, (...params) => {
-            this.testFeatureIsSupportedInBrowser(...params);
-        });
+        this.compatCSS = new CompatCSS(context, this.testFeatureIsSupportedInBrowser.bind(this));
 
         context.on('parse::end::css', async (styleParse: StyleParse) => {
             await this.onParseCSS(styleParse);

--- a/packages/hint-compat-api/src/compat-api-css-next.ts
+++ b/packages/hint-compat-api/src/compat-api-css-next.ts
@@ -3,14 +3,11 @@
  */
 
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { IHint, ProblemLocation } from 'hint/dist/src/lib/types';
-import { StyleParse, StyleEvents } from '@hint/parser-css/dist/src/types';
-import { CompatApi, userBrowsers, CompatCSS } from './helpers';
-import { BrowserSupportCollection } from './types';
-import { SimpleSupportStatement, SupportStatement } from './types-mdn.temp';
-import { browserVersions } from './helpers/normalize-version';
+import { StyleEvents } from '@hint/parser-css/dist/src/types';
+import { SimpleSupportStatement, VersionValue } from './types-mdn.temp';
 
-import meta from './meta/compat-api-css';
+import BaseCompatApiCSS from './compat-api-css-base';
+import { CSSFeatureStatus } from './enums';
 
 /*
  * ------------------------------------------------------------------------------
@@ -18,114 +15,40 @@ import meta from './meta/compat-api-css';
  * ------------------------------------------------------------------------------
  */
 
-type UserPrefixes = {
+/* type UserPrefixes = {
     [key: string]: boolean;
-};
+}; */
 
-export default class implements IHint {
-    public static readonly meta = meta;
-
-    private mdnBrowsersCollection: BrowserSupportCollection;
-    private compatApi: CompatApi;
-    private compatCSS: CompatCSS;
-    private userPrefixes: UserPrefixes = {};
-
+export default class extends BaseCompatApiCSS {
+    /* private userPrefixes: UserPrefixes = {}; */
     public constructor(context: HintContext<StyleEvents>) {
-        const isCheckingNotBroadlySupported = true;
-
-        this.mdnBrowsersCollection = userBrowsers.convert(context.targetedBrowsers);
-        this.compatApi = new CompatApi('css', this.mdnBrowsersCollection, isCheckingNotBroadlySupported);
-        this.compatCSS = new CompatCSS(context, (...params) => {
-            this.testFeatureIsSupportedInBrowser(...params);
-        });
-
-        context.on('parse::end::css', async (styleParse: StyleParse) => {
-            await this.onParseCSS(styleParse);
-        });
+        super(context, CSSFeatureStatus.ADDED, true);
     }
 
-    private async onParseCSS(styleParse: StyleParse): Promise<void> {
-        const { resource } = styleParse;
-
-        this.compatCSS.setResource(resource);
-        await this.compatCSS.searchCSSFeatures(this.compatApi.compatDataApi, this.mdnBrowsersCollection, styleParse);
+    public getFeatureVersionValueToAnalyze(browserFeatureSupported: SimpleSupportStatement): VersionValue {
+        return browserFeatureSupported.version_added;
     }
 
-    private async testFeatureIsSupportedInBrowser(browsersToSupport: BrowserSupportCollection, browserToSupportName: string, browserInfo: SupportStatement, featureName: string, prefix?: string, location?: ProblemLocation): Promise<void> {
-        if (!this.compatApi.isBrowserToSupportPartOfBrowsersCollection(browsersToSupport, browserToSupportName)) {
-            return;
-        }
-
-        const browserFeatureSupported = this.compatApi.getSupportStatementFromInfo(browserInfo, prefix);
-
-        if (!browserFeatureSupported) {
-            const message = `${featureName} of CSS was never added on any of your browsers to support.`;
-
-            await this.compatCSS.reportIfThereIsNoInformationAboutCompatibility(message, browsersToSupport, browserToSupportName, featureName, location);
-
-            return;
-        }
-
-        await this.testAddedVersionByBrowsers(browsersToSupport, browserFeatureSupported, browserToSupportName, featureName, location, prefix);
-    }
-
-    private async testAddedVersionByBrowsers(browsersToSupport: BrowserSupportCollection, browserFeatureSupported: SimpleSupportStatement, browserToSupportName: string, featureName: string, location?: ProblemLocation, prefix?: string): Promise<void> {
-        const addedVersion = browserFeatureSupported.version_added;
-
+    public isVersionTestable(version: VersionValue): boolean {
         // If `addedVersion` is true, it means the property has always been implemented
-        if (addedVersion === true) {
-            return;
-        }
+        return version !== true;
+    }
 
+    public isVersionFeatureSupported(version: VersionValue): boolean {
         // Not a common case, but if added version does not exist, was not added.
-        if (!addedVersion) {
-            const message = `${featureName} of CSS is not supported on ${browserToSupportName} browser.`;
-
-            await this.compatCSS.reportError(featureName, message, location);
-
-            return;
-        }
-
-        await this.testNotSupportedVersionsByBrowsers(browsersToSupport, addedVersion, browserToSupportName, featureName, location, prefix);
+        return !!version;
     }
 
-    private async testNotSupportedVersionsByBrowsers(browsersToSupport: BrowserSupportCollection, addedVersion: string, browserToSupportName: string, featureName: string, location?: ProblemLocation, prefix?: string): Promise<void> {
-        const addedVersionNumber = browserVersions.normalize(addedVersion);
-
-        const notSupportedVersions = this.getNotSupportedVersionByBrowsers(browsersToSupport, browserToSupportName, addedVersionNumber, featureName, prefix);
-
-        if (notSupportedVersions.length > 0) {
-            const message = this.compatCSS.generateNotSupportedVersionsError(featureName, notSupportedVersions, 'added', prefix);
-
-            await this.compatCSS.reportError(featureName, message, location);
-        }
+    public isSupportedVersion(currentVersion: number, version: number) {
+        return version >= currentVersion;
     }
 
-    private getNotSupportedVersionByBrowsers(browsersToSupport: BrowserSupportCollection, browserToSupportName: string, addedVersionNumber: number, featureName: string, prefix?: string): string[] {
-        const isBrowserDefined: boolean = !!browsersToSupport[browserToSupportName];
-        const isPrefixInUse: boolean = !prefix && this.checkUserUsedPrefixes(browserToSupportName, featureName);
-        const versions: number[] = isBrowserDefined && !isPrefixInUse ? browsersToSupport[browserToSupportName] : [];
-
-        return versions
-            .filter((version: number) => {
-                const isVersionGreaterThanAddedVersion: boolean = version >= addedVersionNumber;
-
-                if (isVersionGreaterThanAddedVersion && prefix) {
-                    this.addUserUsedPrefixes(browserToSupportName, featureName);
-                }
-
-                return !isVersionGreaterThanAddedVersion;
-            })
-            .map((version: number) => {
-                return `${browserToSupportName} ${browserVersions.deNormalize(version)}`;
-            });
-    }
-
-    private addUserUsedPrefixes(browserName: string, featureName: string): void {
+    // FIXME: This is not checking anything
+/*     private addUserUsedPrefixes(browserName: string, featureName: string): void {
         this.userPrefixes[browserName + featureName] = true;
     }
 
     private checkUserUsedPrefixes (browserName: string, featureName: string): boolean {
         return this.userPrefixes[browserName + featureName];
-    }
+    } */
 }

--- a/packages/hint-compat-api/src/compat-api-css-next.ts
+++ b/packages/hint-compat-api/src/compat-api-css-next.ts
@@ -15,9 +15,11 @@ import { CSSFeatureStatus } from './enums';
  * ------------------------------------------------------------------------------
  */
 
-/* type UserPrefixes = {
-    [key: string]: boolean;
-}; */
+/*
+ * type UserPrefixes = {
+ *    [key: string]: boolean;
+ * };
+ */
 
 export default class extends BaseCompatApiCSS {
     /* private userPrefixes: UserPrefixes = {}; */
@@ -42,13 +44,13 @@ export default class extends BaseCompatApiCSS {
     public isSupportedVersion(currentVersion: number, version: number) {
         return version >= currentVersion;
     }
-
-    // FIXME: This is not checking anything
-/*     private addUserUsedPrefixes(browserName: string, featureName: string): void {
-        this.userPrefixes[browserName + featureName] = true;
-    }
-
-    private checkUserUsedPrefixes (browserName: string, featureName: string): boolean {
-        return this.userPrefixes[browserName + featureName];
-    } */
+/*
+ * private addUserUsedPrefixes(browserName: string, featureName: string): void {
+ *    this.userPrefixes[browserName + featureName] = true;
+ * }
+ *
+ * private checkUserUsedPrefixes (browserName: string, featureName: string): boolean {
+ *    return this.userPrefixes[browserName + featureName];
+ * }
+ */
 }

--- a/packages/hint-compat-api/src/compat-api-css-next.ts
+++ b/packages/hint-compat-api/src/compat-api-css-next.ts
@@ -31,12 +31,12 @@ export default class extends BaseCompatApiCSS {
         return browserFeatureSupported.version_added;
     }
 
-    public isVersionTestable(version: VersionValue): boolean {
+    public isVersionValueTestable(version: VersionValue): boolean {
         // If `addedVersion` is true, it means the property has always been implemented
         return version !== true;
     }
 
-    public isVersionFeatureSupported(version: VersionValue): boolean {
+    public isVersionValueSupported(version: VersionValue): boolean {
         // Not a common case, but if added version does not exist, was not added.
         return !!version;
     }

--- a/packages/hint-compat-api/src/compat-api-css-next.ts
+++ b/packages/hint-compat-api/src/compat-api-css-next.ts
@@ -24,7 +24,7 @@ import { CSSFeatureStatus } from './enums';
 export default class extends BaseCompatApiCSS {
     /* private userPrefixes: UserPrefixes = {}; */
     public constructor(context: HintContext<StyleEvents>) {
-        super(context, CSSFeatureStatus.ADDED, true);
+        super(context, true);
     }
 
     public getFeatureVersionValueToAnalyze(browserFeatureSupported: SimpleSupportStatement): VersionValue {
@@ -43,6 +43,10 @@ export default class extends BaseCompatApiCSS {
 
     public isSupportedVersion(currentVersion: number, version: number) {
         return version >= currentVersion;
+    }
+
+    public getStatusNameValue(): CSSFeatureStatus {
+        return CSSFeatureStatus.Added;
     }
 /*
  * private addUserUsedPrefixes(browserName: string, featureName: string): void {

--- a/packages/hint-compat-api/src/compat-api-css.ts
+++ b/packages/hint-compat-api/src/compat-api-css.ts
@@ -17,7 +17,7 @@ import { CSSFeatureStatus } from './enums';
 
 export default class extends BaseCompatApiCSS {
     public constructor(context: HintContext<StyleEvents>) {
-        super(context, CSSFeatureStatus.SUPPORTED);
+        super(context, false);
     }
 
     public getFeatureVersionValueToAnalyze(browserFeatureSupported: SimpleSupportStatement): VersionValue {
@@ -36,5 +36,9 @@ export default class extends BaseCompatApiCSS {
 
     public isSupportedVersion(currentVersion: number, version: number) {
         return version < currentVersion;
+    }
+
+    public getStatusNameValue(): CSSFeatureStatus {
+        return CSSFeatureStatus.Supported;
     }
 }

--- a/packages/hint-compat-api/src/compat-api-css.ts
+++ b/packages/hint-compat-api/src/compat-api-css.ts
@@ -24,12 +24,12 @@ export default class extends BaseCompatApiCSS {
         return browserFeatureSupported.version_removed;
     }
 
-    public isVersionTestable(version: VersionValue): boolean {
+    public isVersionValueTestable(version: VersionValue): boolean {
         // If there is no removed version, it is not deprecated.
         return !!version;
     }
 
-    public isVersionFeatureSupported(version: VersionValue): boolean {
+    public isVersionValueSupported(version: VersionValue): boolean {
         // Not a common case, but if removed version is exactly true, is always deprecated.
         return version !== true;
     }

--- a/packages/hint-compat-api/src/compat-api-css.ts
+++ b/packages/hint-compat-api/src/compat-api-css.ts
@@ -3,14 +3,11 @@
  */
 
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { IHint, ProblemLocation } from 'hint/dist/src/lib/types';
-import { StyleParse, StyleEvents } from '@hint/parser-css/dist/src/types';
-import { CompatApi, userBrowsers, CompatCSS } from './helpers';
-import { BrowserSupportCollection } from './types';
-import { SimpleSupportStatement, SupportStatement } from './types-mdn.temp';
-import { browserVersions } from './helpers/normalize-version';
+import { StyleEvents } from '@hint/parser-css/dist/src/types';
+import { SimpleSupportStatement, VersionValue } from './types-mdn.temp';
 
-import meta from './meta/compat-api-css';
+import BaseCompatApiCSS from './compat-api-css-base';
+import { CSSFeatureStatus } from './enums';
 
 /*
  * ------------------------------------------------------------------------------
@@ -18,99 +15,26 @@ import meta from './meta/compat-api-css';
  * ------------------------------------------------------------------------------
  */
 
-export default class implements IHint {
-    public static readonly meta = meta;
-
-    private mdnBrowsersCollection: BrowserSupportCollection;
-    private compatApi: CompatApi;
-    private compatCSS: CompatCSS;
-
+export default class extends BaseCompatApiCSS {
     public constructor(context: HintContext<StyleEvents>) {
-        this.mdnBrowsersCollection = userBrowsers.convert(context.targetedBrowsers);
-        this.compatApi = new CompatApi('css', this.mdnBrowsersCollection);
-        this.compatCSS = new CompatCSS(context, (...params) => {
-            this.testFeatureIsSupportedInBrowser(...params);
-        });
-
-        context.on('parse::end::css', async (styleParse: StyleParse) => {
-            await this.onParseCSS(styleParse);
-        });
+        super(context, CSSFeatureStatus.SUPPORTED);
     }
 
-    private async onParseCSS(styleParse: StyleParse): Promise<void> {
-        const { resource } = styleParse;
-
-        this.compatCSS.setResource(resource);
-        await this.compatCSS.searchCSSFeatures(this.compatApi.compatDataApi, this.mdnBrowsersCollection, styleParse);
+    public getFeatureVersionValueToAnalyze(browserFeatureSupported: SimpleSupportStatement): VersionValue {
+        return browserFeatureSupported.version_removed;
     }
 
-    private async testFeatureIsSupportedInBrowser(browsersToSupport: BrowserSupportCollection, browserToSupportName: string, browserInfo: SupportStatement, featureName: string, prefix?: string, location?: ProblemLocation): Promise<void> {
-        if (!this.compatApi.isBrowserToSupportPartOfBrowsersCollection(browsersToSupport, browserToSupportName)) {
-            return;
-        }
-
-        const browserFeatureSupported = this.compatApi.getSupportStatementFromInfo(browserInfo, prefix);
-
-        if (!browserFeatureSupported) {
-            const message = `${featureName} of CSS was never supported on any of your browsers to support.`;
-
-            await this.compatCSS.reportIfThereIsNoInformationAboutCompatibility(message, browsersToSupport, browserToSupportName, featureName, location);
-
-            return;
-        }
-
-        await this.testRemovedVersionByBrowsers(browsersToSupport, browserFeatureSupported, browserToSupportName, featureName, location, prefix);
-    }
-
-    private async testRemovedVersionByBrowsers(browsersToSupport: BrowserSupportCollection, browserFeatureSupported: SimpleSupportStatement, browserToSupportName: string, featureName: string, location?: ProblemLocation, prefix?: string): Promise<void> {
-        const removedVersion = browserFeatureSupported.version_removed;
-
+    public isVersionTestable(version: VersionValue): boolean {
         // If there is no removed version, it is not deprecated.
-        if (!removedVersion) {
-            return;
-        }
+        return !!version;
+    }
 
+    public isVersionFeatureSupported(version: VersionValue): boolean {
         // Not a common case, but if removed version is exactly true, is always deprecated.
-        if (removedVersion === true) {
-            const message = `${featureName} of CSS is not supported on ${browserToSupportName} browser.`;
-
-            await this.compatCSS.reportError(featureName, message, location);
-
-            return;
-        }
-
-        await this.testNotSupportedVersionsByBrowsers(browsersToSupport, removedVersion, browserToSupportName, featureName, location, prefix);
+        return version !== true;
     }
 
-    private async testNotSupportedVersionsByBrowsers(browsersToSupport: BrowserSupportCollection, removedVersion: string, browserToSupportName: string, featureName: string, location?: ProblemLocation, prefix?: string): Promise<void> {
-        const removedVersionNumber = browserVersions.normalize(removedVersion);
-
-        const notSupportedVersions = this.getNotSupportedVersionByBrowsers(browsersToSupport, browserToSupportName, removedVersionNumber);
-
-        if (notSupportedVersions.length > 0) {
-            const message = this.compatCSS.generateNotSupportedVersionsError(featureName, notSupportedVersions, 'supported', prefix);
-
-            await this.compatCSS.reportError(featureName, message, location);
-        }
-    }
-
-    private getNotSupportedVersionByBrowsers(browsersToSupport: BrowserSupportCollection, browserToSupportName: string, removedVersionNumber: number): string[] {
-        const notSupportedVersions: string[] = [];
-
-        Object.entries(browsersToSupport).forEach(([browserName, versions]) => {
-            if (browserName !== browserToSupportName) {
-                return;
-            }
-
-            versions.forEach((version) => {
-                if (version < removedVersionNumber) {
-                    return;
-                }
-
-                notSupportedVersions.push(`${browserName} ${browserVersions.deNormalize(version)}`);
-            });
-        });
-
-        return notSupportedVersions;
+    public isSupportedVersion(currentVersion: number, version: number) {
+        return version < currentVersion;
     }
 }

--- a/packages/hint-compat-api/src/enums.ts
+++ b/packages/hint-compat-api/src/enums.ts
@@ -1,0 +1,5 @@
+export enum CSSFeatureStatus {
+    REMOVED = 'removed',
+    ADDED = 'added',
+    SUPPORTED = 'supported'
+}

--- a/packages/hint-compat-api/src/enums.ts
+++ b/packages/hint-compat-api/src/enums.ts
@@ -1,5 +1,5 @@
 export enum CSSFeatureStatus {
-    REMOVED = 'removed',
-    ADDED = 'added',
-    SUPPORTED = 'supported'
+    Added = 'added',
+    Removed = 'removed',
+    Supported = 'supported'
 }

--- a/packages/hint-compat-api/src/helpers/compat-css.ts
+++ b/packages/hint-compat-api/src/helpers/compat-css.ts
@@ -7,7 +7,7 @@ import { StyleParse } from '@hint/parser-css/dist/src/types';
 import { ProblemLocation } from 'hint/dist/src/lib/types';
 import { AtRule, Rule, Declaration, ChildNode } from 'postcss';
 import { find } from 'lodash';
-import { FeatureStrategy, MDNTreeFilteredByBrowsers, BrowserSupportCollection, CSSTestFunction, StrategyData, BrowserVersions } from '../types';
+import { FeatureStrategy, MDNTreeFilteredByBrowsers, BrowserSupportCollection, CSSTestFunction, BrowserVersions, FeatureInfo, BrowserInfo } from '../types';
 import { CachedCompatFeatures } from './cached-compat-features';
 import { SupportBlock } from '../types-mdn.temp';
 import { browserVersions } from './normalize-version';
@@ -142,11 +142,14 @@ export class CompatCSS {
                 return;
             }
 
-            this.testFunction(browsersToSupport, browserToSupportName, browserInfo, featureName, prefix, location);
+            const info: BrowserInfo = { browserInfo, browsersToSupport, browserToSupportName };
+            const feature: FeatureInfo = { featureInfo: null, featureName, location, prefix };
+
+            this.testFunction(info, feature);
         });
     }
 
-    public validateStrategy(strategyName: string, featureNameWithPrefix: string, data: MDNTreeFilteredByBrowsers, optionalChildrenNameWithPrefix?: string): StrategyData | null {
+    public validateStrategy(strategyName: string, featureNameWithPrefix: string, data: MDNTreeFilteredByBrowsers, optionalChildrenNameWithPrefix?: string): FeatureInfo | null {
         let [prefix, featureName] = this.getPrefix(featureNameWithPrefix);
 
         const strategyContent: any = data[strategyName];

--- a/packages/hint-compat-api/src/helpers/compat-css.ts
+++ b/packages/hint-compat-api/src/helpers/compat-css.ts
@@ -7,7 +7,7 @@ import { StyleParse } from '@hint/parser-css/dist/src/types';
 import { ProblemLocation } from 'hint/dist/src/lib/types';
 import { AtRule, Rule, Declaration, ChildNode } from 'postcss';
 import { find } from 'lodash';
-import { FeatureStrategy, MDNTreeFilteredByBrowsers, BrowserSupportCollection, CSSTestFunction, BrowserVersions, FeatureInfo, BrowserInfo } from '../types';
+import { FeatureStrategy, MDNTreeFilteredByBrowsers, BrowserSupportCollection, CSSTestFunction, BrowserVersions, FeatureInfo, BrowsersInfo } from '../types';
 import { CachedCompatFeatures } from './cached-compat-features';
 import { SupportBlock } from '../types-mdn.temp';
 import { browserVersions } from './normalize-version';
@@ -142,7 +142,7 @@ export class CompatCSS {
                 return;
             }
 
-            const info: BrowserInfo = { browserInfo, browsersToSupport, browserToSupportName };
+            const info: BrowsersInfo = { browserInfo, browsersToSupport, browserToSupportName };
             const feature: FeatureInfo = { featureInfo: null, featureName, location, prefix };
 
             this.testFunction(info, feature);

--- a/packages/hint-compat-api/src/types-mdn.temp.ts
+++ b/packages/hint-compat-api/src/types-mdn.temp.ts
@@ -30,7 +30,7 @@ type BrowserNames =
  * is only one of them, the array must be omitted.
  */
 export type SupportStatement = SimpleSupportStatement | SimpleSupportStatement[];
-type VersionValue = string | boolean | null;
+export type VersionValue = string | boolean | null | undefined;
 
 /**
  * The `simple_support_statement` object is the core object containing the compatibility information for a browser.

--- a/packages/hint-compat-api/src/types.ts
+++ b/packages/hint-compat-api/src/types.ts
@@ -1,5 +1,5 @@
 import { ChildNode } from 'postcss';
-import { Identifier } from './types-mdn.temp'; // Temporal
+import { Identifier, SupportStatement } from './types-mdn.temp'; // Temporal
 import { ProblemLocation } from 'hint/dist/src/lib/types';
 
 export type MDNTreeFilteredByBrowsers = Identifier;
@@ -13,14 +13,21 @@ export type FeatureStrategy<T extends ChildNode> = {
     testFeature: (node: T, data: MDNTreeFilteredByBrowsers, browsers: BrowserSupportCollection, location?: ProblemLocation) => void;
 };
 
-export type CSSTestFunction = (browsersToSupport: BrowserSupportCollection, browserToSupportName: string, browserInfo: any, featureName: string, prefix?: string, location?: ProblemLocation) => void;
-
-export type StrategyData = {
-    prefix: string | undefined;
-    featureName: string;
-    featureInfo: any;
-};
+export type CSSTestFunction = (browser: BrowserInfo, feature: FeatureInfo) => void;
 
 export type BrowserVersions = {
     [key: string]: string[];
+};
+
+export type FeatureInfo = {
+    featureName: string;
+    featureInfo: any;
+    prefix?: string | undefined;
+    location?: ProblemLocation;
+};
+
+export type BrowserInfo = {
+    browsersToSupport: BrowserSupportCollection;
+    browserToSupportName: string;
+    browserInfo: SupportStatement;
 };

--- a/packages/hint-compat-api/src/types.ts
+++ b/packages/hint-compat-api/src/types.ts
@@ -13,7 +13,7 @@ export type FeatureStrategy<T extends ChildNode> = {
     testFeature: (node: T, data: MDNTreeFilteredByBrowsers, browsers: BrowserSupportCollection, location?: ProblemLocation) => void;
 };
 
-export type CSSTestFunction = (browser: BrowserInfo, feature: FeatureInfo) => void;
+export type CSSTestFunction = (browser: BrowsersInfo, feature: FeatureInfo) => void;
 
 export type BrowserVersions = {
     [key: string]: string[];
@@ -26,7 +26,7 @@ export type FeatureInfo = {
     location?: ProblemLocation;
 };
 
-export type BrowserInfo = {
+export type BrowsersInfo = {
     browsersToSupport: BrowserSupportCollection;
     browserToSupportName: string;
     browserInfo: SupportStatement;


### PR DESCRIPTION
Main goal of this PR consist on reducing the amount of duplicated code between both `compat-api-css` Hints. I'm just leaving the behavior attached to every specific Hint. 

I'm not 100% sure if we can move some of the functionalities to  `CompatCSS` helper.